### PR TITLE
[kebs-spray-json] Support for case classes with more than 22 fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ case class Thing(thingId: String, parent: Option[Thing])
 implicit val thingFormat: RootJsonFormat[Thing] = jsonFormatRec[Thing]
 ```
 
+`kebs-spray-json` also provides JSON formats for case classes with more than 22 fields.
+
 #### - kebs eliminates play-json induced boilerplate (kebs-play-json)
 
 To be honest `play-json` has never been a source of extensive boilerplate for me- thanks to `Json.format[CC]` macro.

--- a/macro-utils/src/main/scala/pl/iterators/kebs/macros/MacroUtils.scala
+++ b/macro-utils/src/main/scala/pl/iterators/kebs/macros/MacroUtils.scala
@@ -6,6 +6,7 @@ abstract class MacroUtils {
   val c: whitebox.Context
 
   protected val _this = c.prefix.tree
+  protected val maxCaseClassFields = 22
 
   import c.universe._
 

--- a/spray-json/src/main/scala/pl/iterators/kebs/json/KebsSpray.scala
+++ b/spray-json/src/main/scala/pl/iterators/kebs/json/KebsSpray.scala
@@ -1,6 +1,6 @@
 package pl.iterators.kebs.json
 
-import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, JsonReader, RootJsonFormat}
 
 trait KebsSpray { self: DefaultJsonProtocol =>
   import macros.KebsSprayMacros
@@ -9,6 +9,10 @@ trait KebsSpray { self: DefaultJsonProtocol =>
 
   final def jsonFormatRec[T <: Product]: RootJsonFormat[T] = macro KebsSprayMacros.materializeLazyFormat[T]
   @inline final def constructJsonFormat[T](reader: JsValue => T, writer: T => JsValue) = jsonFormat(reader, writer)
+
+  implicit class PimpedJsValue(jsValue: JsValue) {
+    def getField[T](fieldName: String)(implicit jr: JsonReader[T]): T = fromField[T](jsValue, fieldName)
+  }
 }
 
 object KebsSpray {

--- a/spray-json/src/test/scala/SprayJsonFormatSnakifyVariantTests.scala
+++ b/spray-json/src/test/scala/SprayJsonFormatSnakifyVariantTests.scala
@@ -1,6 +1,6 @@
 import org.scalatest.{FunSuite, Matchers}
 import pl.iterators.kebs.json.KebsSpray
-import spray.json.{DefaultJsonProtocol, JsNumber, JsObject, JsString, JsonFormat, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol, JsArray, JsBoolean, JsNull, JsNumber, JsObject, JsString, JsonFormat, RootJsonFormat}
 
 class SprayJsonFormatSnakifyVariantTests extends FunSuite with Matchers {
   object KebsProtocol extends DefaultJsonProtocol with KebsSpray.Snakified
@@ -51,5 +51,64 @@ class SprayJsonFormatSnakifyVariantTests extends FunSuite with Matchers {
     jf.read(JsObject("c_field" -> JsNumber(10), "d_field" -> JsObject("int_field" -> JsNumber(100), "string_field" -> JsString("abb")))) shouldBe Compound(
       C(10),
       D(100, "abb"))
+  }
+
+  test("Root format snakified - case class with > 22 fields (issue #7)") {
+    import model._
+
+    val jf = implicitly[JsonFormat[ClassWith23Fields]]
+    val obj = ClassWith23Fields(
+      "f1 value",
+      2,
+      3L,
+      None,
+      Some("f5 value"),
+      "six",
+      List("f7 value 1", "f7 value 2"),
+      "f8 value",
+      "f9 value",
+      "f10 value",
+      "f11 value",
+      "f12 value",
+      "f13 value",
+      "f14 value",
+      "f15 value",
+      "f16 value",
+      "f17 value",
+      "f18 value",
+      "f19 value",
+      "f20 value",
+      "f21 value",
+      "f22 value",
+      true
+    )
+    val json = JsObject(Map(
+      "f1" -> JsString("f1 value"),
+      "f2" -> JsNumber(2),
+      "f3" -> JsNumber(3),
+      "f4" -> JsNull,
+      "f5" -> JsString("f5 value"),
+      "field_number_six" -> JsString("six"),
+      "f7" -> JsArray(JsString("f7 value 1"), JsString("f7 value 2")),
+      "f8" -> JsString("f8 value"),
+      "f9" -> JsString("f9 value"),
+      "f10" -> JsString("f10 value"),
+      "f11" -> JsString("f11 value"),
+      "f12" -> JsString("f12 value"),
+      "f13" -> JsString("f13 value"),
+      "f14" -> JsString("f14 value"),
+      "f15" -> JsString("f15 value"),
+      "f16" -> JsString("f16 value"),
+      "f17" -> JsString("f17 value"),
+      "f18" -> JsString("f18 value"),
+      "f19" -> JsString("f19 value"),
+      "f20" -> JsString("f20 value"),
+      "f21" -> JsString("f21 value"),
+      "f22" -> JsString("f22 value"),
+      "f23" -> JsBoolean(true)
+    ))
+
+    jf.write(obj) shouldBe json
+    jf.read(json) shouldBe obj
   }
 }

--- a/spray-json/src/test/scala/SprayJsonFormatTests.scala
+++ b/spray-json/src/test/scala/SprayJsonFormatTests.scala
@@ -156,4 +156,63 @@ class SprayJsonFormatTests extends FunSuite with Matchers {
     jf.read(json) shouldBe instance
     jf.write(instance) shouldBe json
   }
+
+  test("Root format - case class with > 22 fields (issue #7)") {
+    import model._
+
+    val jf = implicitly[JsonFormat[ClassWith23Fields]]
+    val obj = ClassWith23Fields(
+      "f1 value",
+      2,
+      3L,
+      None,
+      Some("f5 value"),
+      "six",
+      List("f7 value 1", "f7 value 2"),
+      "f8 value",
+      "f9 value",
+      "f10 value",
+      "f11 value",
+      "f12 value",
+      "f13 value",
+      "f14 value",
+      "f15 value",
+      "f16 value",
+      "f17 value",
+      "f18 value",
+      "f19 value",
+      "f20 value",
+      "f21 value",
+      "f22 value",
+      true
+    )
+    val json = JsObject(Map(
+      "f1" -> JsString("f1 value"),
+      "f2" -> JsNumber(2),
+      "f3" -> JsNumber(3),
+      "f4" -> JsNull,
+      "f5" -> JsString("f5 value"),
+      "fieldNumberSix" -> JsString("six"),
+      "f7" -> JsArray(JsString("f7 value 1"), JsString("f7 value 2")),
+      "f8" -> JsString("f8 value"),
+      "f9" -> JsString("f9 value"),
+      "f10" -> JsString("f10 value"),
+      "f11" -> JsString("f11 value"),
+      "f12" -> JsString("f12 value"),
+      "f13" -> JsString("f13 value"),
+      "f14" -> JsString("f14 value"),
+      "f15" -> JsString("f15 value"),
+      "f16" -> JsString("f16 value"),
+      "f17" -> JsString("f17 value"),
+      "f18" -> JsString("f18 value"),
+      "f19" -> JsString("f19 value"),
+      "f20" -> JsString("f20 value"),
+      "f21" -> JsString("f21 value"),
+      "f22" -> JsString("f22 value"),
+      "f23" -> JsBoolean(true)
+    ))
+
+    jf.write(obj) shouldBe json
+    jf.read(json) shouldBe obj
+  }
 }

--- a/spray-json/src/test/scala/model/package.scala
+++ b/spray-json/src/test/scala/model/package.scala
@@ -1,0 +1,28 @@
+package object model {
+
+  case class ClassWith23Fields(
+    f1: String,
+    f2: Int,
+    f3: Long,
+    f4: Option[String],
+    f5: Option[String],
+    fieldNumberSix: String,
+    f7: List[String],
+    f8: String,
+    f9: String,
+    f10: String,
+    f11: String,
+    f12: String,
+    f13: String,
+    f14: String,
+    f15: String,
+    f16: String,
+    f17: String,
+    f18: String,
+    f19: String,
+    f20: String,
+    f21: String,
+    f22: String,
+    f23: Boolean
+  )
+}


### PR DESCRIPTION
It fixes #7 

Please review @marcin-rzeznicki 