### PR TITLE
Properly handle None values in spray-json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val publishToNexus = publishTo := {
     Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
-lazy val crossBuildSettings = Seq(crossScalaVersions := scala_2_13 +: supportedScalaVersions, releaseCrossBuild := true)
+lazy val crossBuildSettings = Seq(crossScalaVersions := supportedScalaVersions, releaseCrossBuild := true)
 
 lazy val publishSettings = Seq(
   publishToNexus,
@@ -85,7 +85,7 @@ def paradisePlugin(scalaVersion: String): Seq[ModuleID] =
   else
     Seq.empty
 
-val scalaTest     = "org.scalatest" %% "scalatest" % "3.2.1"
+val scalaTest     = "org.scalatest" %% "scalatest" % "3.2.2"
 val slick         = "com.typesafe.slick" %% "slick" % "3.3.2"
 val optionalSlick = optional(slick)
 val slickPg       = "com.github.tminglei" %% "slick-pg" % "0.19.2"

--- a/spray-json/src/main/scala/pl/iterators/kebs/json/KebsSpray.scala
+++ b/spray-json/src/main/scala/pl/iterators/kebs/json/KebsSpray.scala
@@ -1,7 +1,7 @@
 package pl.iterators.kebs.json
 
 import pl.iterators.kebs.macros.CaseClass1Rep
-import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, JsonReader, JsonWriter, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol, JsField, JsValue, JsonFormat, JsonReader, JsonWriter, RootJsonFormat}
 
 trait KebsSpray { self: DefaultJsonProtocol =>
   import macros.KebsSprayMacros
@@ -16,7 +16,9 @@ trait KebsSpray { self: DefaultJsonProtocol =>
 
   @inline
   def _kebs_getField[T](value: JsValue, fieldName: String)(implicit reader: JsonReader[T]) = fromField[T](value, fieldName)
-
+  @inline
+  def _kebs_productElement2Field[T](fieldName: String, p: Product, ix: Int, rest: List[JsField] = Nil)(
+      implicit writer: JsonWriter[T]): List[JsField] = productElement2Field[T](fieldName, p, ix, rest)
 }
 
 object KebsSpray {

--- a/spray-json/src/test/scala/SprayJsonFormatSnakifyVariantTests.scala
+++ b/spray-json/src/test/scala/SprayJsonFormatSnakifyVariantTests.scala
@@ -1,5 +1,5 @@
 import pl.iterators.kebs.json.KebsSpray
-import spray.json.{DefaultJsonProtocol, JsArray, JsBoolean, JsNull, JsNumber, JsObject, JsString, JsonFormat, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol, JsArray, JsBoolean, JsNull, JsNumber, JsObject, JsString, JsonFormat, NullOptions, RootJsonFormat}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -56,6 +56,68 @@ class SprayJsonFormatSnakifyVariantTests extends AnyFunSuite with Matchers {
 
   test("Root format snakified - case class with > 22 fields (issue #7)") {
     import model._
+
+    val jf = implicitly[JsonFormat[ClassWith23Fields]]
+    val obj = ClassWith23Fields(
+      F1("f1 value"),
+      2,
+      3L,
+      None,
+      Some("f5 value"),
+      "six",
+      List("f7 value 1", "f7 value 2"),
+      "f8 value",
+      "f9 value",
+      "f10 value",
+      "f11 value",
+      "f12 value",
+      "f13 value",
+      "f14 value",
+      "f15 value",
+      "f16 value",
+      "f17 value",
+      "f18 value",
+      "f19 value",
+      "f20 value",
+      "f21 value",
+      "f22 value",
+      true
+    )
+    val json = JsObject(
+      Map(
+        "f1"               -> JsString("f1 value"),
+        "f2"               -> JsNumber(2),
+        "f3"               -> JsNumber(3),
+        "f5"               -> JsString("f5 value"),
+        "field_number_six" -> JsString("six"),
+        "f7"               -> JsArray(JsString("f7 value 1"), JsString("f7 value 2")),
+        "f8"               -> JsString("f8 value"),
+        "f9"               -> JsString("f9 value"),
+        "f10"              -> JsString("f10 value"),
+        "f11"              -> JsString("f11 value"),
+        "f12"              -> JsString("f12 value"),
+        "f13"              -> JsString("f13 value"),
+        "f14"              -> JsString("f14 value"),
+        "f15"              -> JsString("f15 value"),
+        "f16"              -> JsString("f16 value"),
+        "f17"              -> JsString("f17 value"),
+        "f18"              -> JsString("f18 value"),
+        "f19"              -> JsString("f19 value"),
+        "f20"              -> JsString("f20 value"),
+        "f21"              -> JsString("f21 value"),
+        "f22"              -> JsString("f22 value"),
+        "f23"              -> JsBoolean(true)
+      ))
+
+    jf.write(obj) shouldBe json
+    jf.read(json) shouldBe obj
+  }
+
+  test("Root format snakified with NullOptions - case class with > 22 fields (issue #73)") {
+    object KebsProtocolNullOptions extends DefaultJsonProtocol with KebsSpray with NullOptions
+
+    import model._
+    import KebsProtocolNullOptions._
 
     val jf = implicitly[JsonFormat[ClassWith23Fields]]
     val obj = ClassWith23Fields(

--- a/spray-json/src/test/scala/SprayJsonFormatTests.scala
+++ b/spray-json/src/test/scala/SprayJsonFormatTests.scala
@@ -193,6 +193,68 @@ class SprayJsonFormatTests extends AnyFunSuite with Matchers {
         "f1"             -> JsString("f1 value"),
         "f2"             -> JsNumber(2),
         "f3"             -> JsNumber(3),
+        "f5"             -> JsString("f5 value"),
+        "fieldNumberSix" -> JsString("six"),
+        "f7"             -> JsArray(JsString("f7 value 1"), JsString("f7 value 2")),
+        "f8"             -> JsString("f8 value"),
+        "f9"             -> JsString("f9 value"),
+        "f10"            -> JsString("f10 value"),
+        "f11"            -> JsString("f11 value"),
+        "f12"            -> JsString("f12 value"),
+        "f13"            -> JsString("f13 value"),
+        "f14"            -> JsString("f14 value"),
+        "f15"            -> JsString("f15 value"),
+        "f16"            -> JsString("f16 value"),
+        "f17"            -> JsString("f17 value"),
+        "f18"            -> JsString("f18 value"),
+        "f19"            -> JsString("f19 value"),
+        "f20"            -> JsString("f20 value"),
+        "f21"            -> JsString("f21 value"),
+        "f22"            -> JsString("f22 value"),
+        "f23"            -> JsBoolean(true)
+      ))
+
+    jf.write(obj) shouldBe json
+    jf.read(json) shouldBe obj
+  }
+
+  test("Root format with NullOptions - case class with > 22 fields (issue #73)") {
+    object KebsProtocolNullOptions extends DefaultJsonProtocol with KebsSpray with NullOptions
+
+    import model._
+    import KebsProtocolNullOptions._
+
+    val jf = implicitly[JsonFormat[ClassWith23Fields]]
+    val obj = ClassWith23Fields(
+      F1("f1 value"),
+      2,
+      3L,
+      None,
+      Some("f5 value"),
+      "six",
+      List("f7 value 1", "f7 value 2"),
+      "f8 value",
+      "f9 value",
+      "f10 value",
+      "f11 value",
+      "f12 value",
+      "f13 value",
+      "f14 value",
+      "f15 value",
+      "f16 value",
+      "f17 value",
+      "f18 value",
+      "f19 value",
+      "f20 value",
+      "f21 value",
+      "f22 value",
+      true
+    )
+    val json = JsObject(
+      Map(
+        "f1"             -> JsString("f1 value"),
+        "f2"             -> JsNumber(2),
+        "f3"             -> JsNumber(3),
         "f4"             -> JsNull,
         "f5"             -> JsString("f5 value"),
         "fieldNumberSix" -> JsString("six"),


### PR DESCRIPTION
Previously case classes with more than 22 fields were always serialized as nulls. This is not default behaviour in spray-json. They should be rendered as null only if NullOptions trait is mixed in.

Fixes #73