### PR TITLE
Remove compiler warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# Build Server Protocol
+/.bsp/
+
 ### Linux template
 *~
 

--- a/akka-http/src/test/scala/AkkaHttpUnmarshallerTests.scala
+++ b/akka-http/src/test/scala/AkkaHttpUnmarshallerTests.scala
@@ -78,7 +78,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   }
 
   test("Unmarshalling parameter") {
-    val testRoute = parameters('i.as[I]) { i =>
+    val testRoute = parameters(Symbol("i").as[I]) { i =>
       complete(i.toString)
     }
     Get("/?i=42") ~> testRoute ~> check {
@@ -87,7 +87,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   }
 
   test("Unmarshalling optional parameter") {
-    val testRoute = parameters('i.as[I].?) { i =>
+    val testRoute = parameters(Symbol("i").as[I].?) { i =>
       complete(i.toString)
     }
     Get("/?i=42") ~> testRoute ~> check {
@@ -96,7 +96,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   }
 
   test("Unmarshalling enum parameter") {
-    val testRoute = parameters('greeting.as[Greeting]) { greeting =>
+    val testRoute = parameters(Symbol("greeting").as[Greeting]) { greeting =>
       complete(greeting.toString)
     }
     Get("/?greeting=hi") ~> testRoute ~> check {
@@ -110,7 +110,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   }
 
   test("Unmarshalling value enum parameter") {
-    val testRoute = parameters('libraryItem.as[LibraryItem]) { item =>
+    val testRoute = parameters(Symbol("libraryItem").as[LibraryItem]) { item =>
       complete(item.toString)
     }
     Get("/?libraryItem=1") ~> testRoute ~> check {
@@ -129,7 +129,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   test("Case class extraction") {
     val route =
       path("color") {
-        parameters('red.as[Red], 'green.as[Green], 'blue.as[Blue]).as(Color) { color =>
+        parameters(Symbol("red").as[Red], Symbol("green").as[Green], Symbol("blue").as[Blue]).as(Color) { color =>
           complete(color.toString)
         }
       }
@@ -150,7 +150,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   }
 
   test("Unmarshalling string value enum parameter") {
-    val testRoute = parameters('shirtSize.as[ShirtSize]) { shirtSize =>
+    val testRoute = parameters(Symbol("shirtSize").as[ShirtSize]) { shirtSize =>
       complete(shirtSize.toString)
     }
     Get("/?shirtSize=M") ~> testRoute ~> check {
@@ -172,7 +172,7 @@ class AkkaHttpUnmarshallerTests extends AnyFunSuite with Matchers with Scalatest
   test("bug: work with default enum values") {
     val route =
       path("test_enum") {
-        parameter('sort.as[SortOrder] ? (SortOrder.Desc: SortOrder)) { sort =>
+        parameter(Symbol("sort").as[SortOrder] ? (SortOrder.Desc: SortOrder)) { sort =>
           complete {
             s"Sort was $sort"
           }

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val scala_2_12             = "2.12.12"
-val scala_2_13             = "2.13.3"
+val scala_2_13             = "2.13.4"
 val mainScalaVersion       = scala_2_13
 val supportedScalaVersions = Seq(scala_2_12, scala_2_13)
 

--- a/slick/src/test/scala/SlickPgArrayColumnTypeTests.scala
+++ b/slick/src/test/scala/SlickPgArrayColumnTypeTests.scala
@@ -8,8 +8,8 @@ class SlickPgArrayColumnTypeTests extends AnyFunSuite with Matchers {
   case class MarketFinancialProduct(value: String)
 
   object MyPostgresProfile extends ExPostgresProfile with PgArraySupport {
-    override val api: API = new API {}
-    trait API extends super.API with ArrayImplicits
+    override val api: APIWithArrays = new APIWithArrays {}
+    trait APIWithArrays extends super.API with ArrayImplicits
   }
 
   import MyPostgresProfile.api._

--- a/slick/src/test/scala/SlickPgHstoreColumnTypeTests.scala
+++ b/slick/src/test/scala/SlickPgHstoreColumnTypeTests.scala
@@ -7,8 +7,8 @@ class SlickPgHstoreColumnTypeTests extends AnyFunSuite with Matchers {
   case class CategoryImportance(value: Int)
 
   object MyPostgresProfile extends ExPostgresProfile with PgHStoreSupport {
-    override val api: API = new API {}
-    trait API extends super.API with HStoreImplicits
+    override val api: APIWithHStore = new APIWithHStore {}
+    trait APIWithHStore extends super.API with HStoreImplicits
   }
 
   import MyPostgresProfile.api._

--- a/tagged-meta/src/main/scala/pl/iterators/kebs/tag/meta/tagged.scala
+++ b/tagged-meta/src/main/scala/pl/iterators/kebs/tag/meta/tagged.scala
@@ -94,7 +94,7 @@ final class macroImpl(val c: whitebox.Context) {
         else List.empty
       val body =
         if (hasValidations)
-          q"validate($argName).right.map(arg1 => $argName.taggedWith[${tagType.tagName}[..$tagParams]])"
+          q"validate($argName).map(arg1 => $argName.taggedWith[${tagType.tagName}[..$tagParams]])"
         else
           q"$argName.taggedWith[${tagType.tagName}[..$tagParams]]"
 

--- a/tagged-meta/src/test/scala/CirceAnnotationTests.scala
+++ b/tagged-meta/src/test/scala/CirceAnnotationTests.scala
@@ -75,6 +75,6 @@ class CirceAnnotationTests extends AnyFunSuite with Matchers with KebsCirce {
   case class C(i: Int, j: CirceTestTags.PositiveInt)
   test("Implicits are found from tag companion object") {
     val decoder: Decoder[C] = implicitly[Decoder[C]]
-    decoder.apply(Json.fromFields(List("i" -> Json.fromInt(1), "j" -> Json.fromInt(2))).hcursor).right.map(_.j) shouldEqual Right(2)
+    decoder.apply(Json.fromFields(List("i" -> Json.fromInt(1), "j" -> Json.fromInt(2))).hcursor).map(_.j) shouldEqual Right(2)
   }
 }

--- a/tagged-meta/src/test/scala/TaggedAnnotationTests.scala
+++ b/tagged-meta/src/test/scala/TaggedAnnotationTests.scala
@@ -61,12 +61,12 @@ class TaggedAnnotationTests extends AnyFunSuite with Matchers with EitherValues 
   }
 
   test("from method must use validation (object)") {
-    PositiveInt.from(10).right.value shouldEqual 10
+    PositiveInt.from(10).value shouldEqual 10
     PositiveInt.from(0).left.value shouldEqual PositiveInt.Zero
   }
 
   test("from method must use validation (trait)") {
-    NegativeInt.from(-10).right.value shouldEqual -10
+    NegativeInt.from(-10).value shouldEqual -10
     NegativeInt.from(0).left.value shouldEqual NegativeInt.Zero
   }
 


### PR DESCRIPTION
Remove Scala 2.12 deprecations

Also:
 * bump Scala version to 2.13.4
 * add `/.bsp/` to .gitignore

Closes #84

There are still two warnings after moving to Scala 2.13.4, but they should be away in the 2.13.5 (see https://github.com/scala/bug/issues/12250).