### PR TITLE
Move to 2.13.12 and remove compile warnings

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,3 @@
+-J-Xmx6G
+-J-Xss2M
+-Duser.timezone=GMT

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import sbt.librarymanagement.ConflictWarning
 
 val scala_2_12             = "2.12.18"
-val scala_2_13             = "2.13.11"
+val scala_2_13             = "2.13.12"
 val scala_3                = "3.3.1"
 val mainScalaVersion       = scala_3
 val supportedScalaVersions = Seq(scala_2_12, scala_2_13, scala_3)

--- a/scalacheck/src/main/scala-2/pl/iterators/kebs/scalacheck/Generators.scala
+++ b/scalacheck/src/main/scala-2/pl/iterators/kebs/scalacheck/Generators.scala
@@ -1,7 +1,6 @@
 package pl.iterators.kebs.scalacheck
 
 import org.scalacheck.Arbitrary
-import pl.iterators.kebs.scalacheck.CommonArbitrarySupport
 
 trait Generator[T] extends CommonArbitrarySupport {
   def ArbT: Arbitrary[T]

--- a/scalacheck/src/main/scala/pl/iterators/kebs/scalacheck/ArbitrarySupport.scala
+++ b/scalacheck/src/main/scala/pl/iterators/kebs/scalacheck/ArbitrarySupport.scala
@@ -91,15 +91,15 @@ trait KebsArbitraryPredefs {
       }
   })
 
-  implicit val arbUrl: Arbitrary[URL] = Arbitrary {
+  implicit val arbUri: Arbitrary[URI] = Arbitrary {
     for {
-      protocol  <- Gen.oneOf("http", "https", "ftp", "file")
-      domain    <- Gen.alphaNumStr
+      protocol <- Gen.oneOf("http", "https", "ftp", "file")
+      domain <- Gen.alphaNumStr
       subdomain <- Gen.alphaNumStr
-      path      <- Gen.alphaNumStr
-    } yield new URL(s"$protocol://$subdomain.$domain.test/$path")
+      path <- Gen.alphaNumStr
+    } yield new URI(s"$protocol://$subdomain.$domain.test/$path")
   }
 
-  implicit val arbUri: Arbitrary[URI] = Arbitrary(arbUrl.arbitrary.map(_.toURI))
+  implicit val arbUrl: Arbitrary[URL] = Arbitrary(arbUri.arbitrary.map(_.toURL))
 
 }

--- a/tagged-meta/src/main/scala/pl/iterators/kebs/tag/meta/tagged.scala
+++ b/tagged-meta/src/main/scala/pl/iterators/kebs/tag/meta/tagged.scala
@@ -121,9 +121,9 @@ final class macroImpl(val c: whitebox.Context) {
       val implicitName = TermName(name.decodedName.toString + "CaseClass1Rep")
 
       if (typeParams.isEmpty)
-        q"implicit val $implicitName = $caseClass1RepInstanceTree"
+        q"implicit val $implicitName: _root_.pl.iterators.kebs.macros.CaseClass1Rep[$selfType, $baseTypeName[..$baseParams]] = $caseClass1RepInstanceTree"
       else
-        q"implicit def $implicitName[..$typeParams] = $caseClass1RepInstanceTree"
+        q"implicit def $implicitName[..$typeParams]: _root_.pl.iterators.kebs.macros.CaseClass1Rep[$selfType, $baseTypeName[..$baseParams]] = $caseClass1RepInstanceTree"
     }
 
     private def containsApply(trees: List[Tree]): Boolean = {


### PR DESCRIPTION
 * implicit generated in macro needs to have type to not
   generate warnings during compile
 * do not use URL constructor, since it is deprecated since JDK 20
 * remove one unnecessary import leading to compile warning

Also: add some more memory for SBT and ensure timezone is GMT for builds