### PR TITLE
EnumLike refactor

### DIFF
--- a/core/src/main/scala/pl/iterators/kebs/core/enums/EnumLike.scala
+++ b/core/src/main/scala/pl/iterators/kebs/core/enums/EnumLike.scala
@@ -3,18 +3,20 @@ package pl.iterators.kebs.core.enums
 import scala.collection.immutable
 
 trait EnumLike[T] {
-  def values: immutable.Seq[T]
-  def getNamesToValuesMap: Map[String, T]                  = EnumLike.namesToValuesMap(this)
-  def withNameOption(name: String): Option[T]              = EnumLike.namesToValuesMap(this).get(name)
-  def withNameUppercaseOnlyOption(name: String): Option[T] = EnumLike.upperCaseNameValuesToMap(this).get(name)
-  def withNameInsensitiveOption(name: String): Option[T]   = EnumLike.lowerCaseNamesToValuesMap(this).get(name.toLowerCase)
-  def withNameLowercaseOnlyOption(name: String): Option[T] = EnumLike.lowerCaseNamesToValuesMap(this).get(name)
+  def valuesToNamesMap: Map[T, String]
+  def values: immutable.Seq[T]                             = valuesToNamesMap.keys.toSeq
+  def names: immutable.Seq[String]                         = valuesToNamesMap.values.toSeq
+  def getNamesToValuesMap: Map[String, T]                  = valuesToNamesMap.map(_.swap)
+  def withNameOption(name: String): Option[T]              = getNamesToValuesMap.get(name)
+  def withNameUppercaseOnlyOption(name: String): Option[T] = valuesToNamesMap.find(_._2.toUpperCase == name).map(_._1)
+  def withNameInsensitiveOption(name: String): Option[T]   = valuesToNamesMap.find(_._2.equalsIgnoreCase(name)).map(_._1)
+  def withNameLowercaseOnlyOption(name: String): Option[T] = valuesToNamesMap.find(_._2.toLowerCase == name).map(_._1)
   def withNameUppercaseOnly(name: String): T =
-    withNameUppercaseOnlyOption(name).getOrElse(throw new NoSuchElementException(EnumLike.buildNotFoundMessage(name, this)))
+    withNameUppercaseOnlyOption(name).getOrElse(throw new NoSuchElementException(buildNotFoundMessage(name)))
   def withNameLowercaseOnly(name: String): T =
-    withNameLowercaseOnlyOption(name).getOrElse(throw new NoSuchElementException(EnumLike.buildNotFoundMessage(name, this)))
+    withNameLowercaseOnlyOption(name).getOrElse(throw new NoSuchElementException(buildNotFoundMessage(name)))
   def withName(name: String): T =
-    withNameOption(name).getOrElse(throw new NoSuchElementException(EnumLike.buildNotFoundMessage(name, this)))
+    withNameOption(name).getOrElse(throw new NoSuchElementException(buildNotFoundMessage(name)))
   def valueOf(name: String): T =
     values.find(_.toString == name).getOrElse(throw new IllegalArgumentException(s"enum case not found: $name"))
   def valueOfIgnoreCase(name: String): T =
@@ -23,17 +25,6 @@ trait EnumLike[T] {
   def withNameIgnoreCaseOption(name: String): Option[T] = values.find(_.toString.equalsIgnoreCase((name)))
   def fromOrdinal(ordinal: Int): T = values.lift(ordinal).getOrElse(throw new NoSuchElementException(ordinal.toString))
   def indexOf(member: T): Int      = values.zipWithIndex.toMap.getOrElse(member, -1)
-}
 
-private[core] object EnumLike {
-  private def namesToValuesMap[T](`enum`: EnumLike[T]): Map[String, T] = `enum`.values.map(v => v.toString -> v).toMap
-  private def upperCaseNameValuesToMap[T](`enum`: EnumLike[T]): Map[String, T] = namesToValuesMap(`enum`).map { case (k, v) =>
-    k.toUpperCase() -> v
-  }
-  private def lowerCaseNamesToValuesMap[T](`enum`: EnumLike[T]): Map[String, T] = namesToValuesMap(`enum`).map { case (k, v) =>
-    k.toLowerCase() -> v
-  }
-  private def existingEntriesString[T](`enum`: EnumLike[T]): String = `enum`.values.map(_.toString).mkString(", ")
-  private def buildNotFoundMessage[T](notFoundName: String, `enum`: EnumLike[T]): String =
-    s"$notFoundName is not a member of Enum (${existingEntriesString(`enum`)})"
+  private def buildNotFoundMessage(name: String): String = s"$name should be one of ${names.mkString(", ")}"
 }

--- a/enum/src/main/scala-2/pl/iterators/kebs/enums/KebsEnum.scala
+++ b/enum/src/main/scala-2/pl/iterators/kebs/enums/KebsEnum.scala
@@ -16,7 +16,7 @@ class EnumerationEntryMacros(val c: blackbox.Context) {
     val objectStr  = valueType.toString.replaceFirst(".Value$", "")
     val objectName = c.typecheck(c.parse(s"$objectStr: $objectStr.type"))
     c.Expr[EnumLike[E]](
-      q"new _root_.pl.iterators.kebs.core.enums.EnumLike[$valueType] { override def values: immutable.Seq[${valueType}] = ($objectName).values.toSeq }"
+      q"new _root_.pl.iterators.kebs.core.enums.EnumLike[$valueType] { override def valuesToNamesMap: Map[$valueType, String] = ($objectName).values.map(v => v -> v.toString).toMap }"
     )
   }
 }

--- a/enum/src/main/scala-3/pl/iterators/kebs/enums/KebsEnum.scala
+++ b/enum/src/main/scala-3/pl/iterators/kebs/enums/KebsEnum.scala
@@ -1,6 +1,5 @@
 package pl.iterators.kebs.enums
 
-import scala.collection.immutable
 import scala.compiletime.{constValue, erasedValue, error, summonInline}
 import scala.deriving.Mirror
 import scala.reflect.Enum
@@ -11,7 +10,7 @@ trait KebsEnum {
   inline implicit def kebsEnumScala[E <: Enum](using m: Mirror.SumOf[E]): EnumLike[E] = {
     val enumValues = summonCases[m.MirroredElemTypes, E]
     new EnumLike[E] {
-      override def values: immutable.Seq[E] = enumValues.toSeq
+      override def valuesToNamesMap: Map[E, String] = enumValues.map(v => v -> v.toString).toMap
     }
   }
 }

--- a/enumeratum/src/main/scala-2/pl/iterators/kebs/enumeratum/KebsEnumeratum.scala
+++ b/enumeratum/src/main/scala-2/pl/iterators/kebs/enumeratum/KebsEnumeratum.scala
@@ -20,7 +20,7 @@ class EnumeratumEntryMacros(val c: blackbox.Context) extends MacroUtils {
     assertEnumEntry(EnumEntry, s"${EnumEntry.typeSymbol} must subclass EnumEntry")
 
     c.Expr[EnumLike[E]](
-      q"new _root_.pl.iterators.kebs.core.enums.EnumLike[${EnumEntry.typeSymbol}] { override def values: Seq[${EnumEntry.typeSymbol}] = ${companion(EnumEntry)}.values.toSeq }"
+      q"new _root_.pl.iterators.kebs.core.enums.EnumLike[${EnumEntry.typeSymbol}] { override def valuesToNamesMap: Map[${EnumEntry.typeSymbol}, String] = ${companion(EnumEntry)}.values.map(v => v -> v.entryName).toMap }"
     )
   }
 }

--- a/enumeratum/src/main/scala-3/pl/iterators/kebs/enumeratum/KebsEnumeratum.scala
+++ b/enumeratum/src/main/scala-3/pl/iterators/kebs/enumeratum/KebsEnumeratum.scala
@@ -1,7 +1,6 @@
 package pl.iterators.kebs.enumeratum
 
 import enumeratum._
-import scala.collection.immutable
 import scala.compiletime.{constValue, erasedValue, error, summonInline}
 import scala.deriving.Mirror
 
@@ -11,7 +10,7 @@ trait KebsEnumeratum {
   inline implicit def enumLikeFromEnumeratum[E <: EnumEntry](using m: Mirror.SumOf[E]): EnumLike[E] = {
     val enumValues = summonCases[m.MirroredElemTypes, E]
     new EnumLike[E] {
-      override def values: immutable.Seq[E] = enumValues.toSeq
+      override def valuesToNamesMap: Map[E, String] = enumValues.map(v => v -> v.entryName).toMap
     }
   }
 }


### PR DESCRIPTION
Refactoring EnumLike so that it's build from Map[E, String] not just values.

This enables better handling in subproject that redefine casing.