### PR TITLE
chore: bump baklava-core to 2.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,7 +113,7 @@ def paradiseFlag(scalaVersion: String): Seq[String] =
 val scalaTest  = Def.setting("org.scalatest" %%% "scalatest" % "3.2.20")
 val scalaCheck = Def.setting("org.scalacheck" %%% "scalacheck" % "1.19.0")
 
-val baklava         = "pl.iterators"        %% "baklava-core"    % "1.4.1"
+val baklava         = "pl.iterators"        %% "baklava-core"    % "2.0.0"
 val slick           = "com.typesafe.slick"  %% "slick"           % "3.6.1"
 val optionalSlick   = optional(slick)
 val playJson        = Def.setting("org.playframework" %%% "play-json" % "3.0.6")


### PR DESCRIPTION
Bumps the `baklava-core` dependency from 1.4.1 to 2.0.0 (latest).

The `kebs-baklava` module compiles cleanly against it — baklava 2.0's only breaking change is the tsrest/tsfetch route-module convention, which `kebs-baklava` does not use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)